### PR TITLE
docs: switch protocol from `http` to `ws`

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -11,7 +11,7 @@ esno server.ts
 now open a few terminal windows and send messages.
 
 ```sh
-$ wscat -c http://localhost:3000/chat
+$ wscat -c ws://localhost:3000/chat
 # > hello
 # < hello
 # < someone else sent this


### PR DESCRIPTION
It seems that `wscat` doesn't like `http`:

```sh
❯ wscat -c http://localhost:3000/chat
SyntaxError: The URL's protocol must be one of "ws:", "wss:", or "ws+unix:"
```

```sh
❯ wscat -V
5.1.0
```